### PR TITLE
Update pn_vrouter_bgp

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,9 @@ Manage vRouters.
 
 **_`bgp_as`_** is the AS number for any BGP interfaces that you will create later. Can be any integer. By default this property is set to `''` and tells Puppet not to set up BGP on the vRouter. (This can always be changed in the manifest later.)
 
+**_`router_id`_** is the IP address assigned to the vRouter, both `router_id` and `bgp_as` must be specified to create a vRouter that can host a BGP interface.
+
+
 **_`switch`_** the switch where the vRouter will live, this can be the name of any switch on the fabric. By deafult this value is set to `local` and creates a vRouter on whatever node is specified in the manifest.
 
 #### Example Implementation
@@ -386,6 +389,8 @@ Manage vRouter BGP interfaces. To create a BGP interface you must first create a
 
 **`bgp_as`** is the AS ID for the BGP interface.
 
+**_`increment`_** is how much the address will be incremented by in a range.
+
 **_`switch`_** is the name of the switch where the vRouter BGP interface will be hosted. This can be any switch on the fabric. The default value is `local` which creates a BGP interface on the node where the resource was declared.
 
 #### Example Implementation
@@ -406,6 +411,7 @@ pn_vrouter { 'demo-vrouter':
     hw-vrrp-id => 18,
     service => enable,
     bgp_as => '65001',
+    router_id => '172.168.85.8',
 }
 
 pn_vlan { '101':
@@ -427,6 +433,13 @@ pn_vrouter_bgp { 'demo-vrouter 101.101.101.1':
     require => Pn_vrouter_ip['101'],
     ensure => present,
     bgp_as => '65001',
+}
+
+pn_vrouter_bgp { 'demo-vrouter 101.101.101.2-10':
+    require => Pn_vrouter_ip['101'],
+    ensure => present,
+    bgp_as => '65001',
+    increment => '2',
 }
 ```
 

--- a/lib/puppet/type/pn_vrouter.rb
+++ b/lib/puppet/type/pn_vrouter.rb
@@ -37,6 +37,9 @@ bgp_as is the AS number for any BGP interfaces that you will create later. Can
 be any integer. By default this property is set to '' and tells Puppet not to
 set up BGP on the vRouter. (This can always be changed in the manifest later.)
 
+router_id is the IP address assigned to the vRouter, both router_id and bgp_as
+must be specified to create a vRouter that can host a BGP interface.
+
 switch the switch where the vRouter will live, this can be the name of any
 switch on the fabric. By deafult this value is set to local and creates a
 vRouter on whatever node is specified in the manifest.
@@ -93,12 +96,13 @@ pn_vrouter { 'demo-vrouter':
   end
 
   newproperty(:service) do
-    desc ""
+    desc "Enables or disables the vRouter."
     defaultto(:enable)
     newvalues(:enable, :disable)
   end
 
   newproperty(:hw_vrrp_id) do
+    desc "A hardware id for VRRP interfaces that may live on this vRouter."
     validate do |value|
       if value =~ /[^\d*$]/
         raise ArgumentError, 'hw_vrrp_id must be a number'
@@ -107,10 +111,22 @@ pn_vrouter { 'demo-vrouter':
   end
 
   newproperty(:bgp_as) do
+    desc "The AS number for any BGP interfaces that will be created later."
     defaultto('')
     validate do |value|
       if value =~ /[^\d*$]/ and value != ''
         raise ArgumentError, 'bgp_as must be a number'
+      end
+    end
+  end
+
+  newproperty(:router_id) do
+    desc "The IP router ID for the vRouter."
+    defaultto('none')
+    validate do |value|
+      if value !~ /(?x)^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.)
+{3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/ and value != 'none'
+        raise ArgumentError, "Router ID must be a valid IP address"
       end
     end
   end

--- a/tests/runs/pn_vrouter_bgp_runs.pp
+++ b/tests/runs/pn_vrouter_bgp_runs.pp
@@ -1,0 +1,181 @@
+# Copyright 2016 Pluribus Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SET-UP
+
+pn_vrouter { 'bgp-test-vrouter-1':
+  ensure     => present,
+  switch     => 'dorado-tme-1',
+  vnet       => 'puppet-ansible-chef-fab-global',
+  service    => 'enable',
+  hw_vrrp_id => 18,
+  bgp_as     => 65000,
+  router_id  => '172.168.10.6',
+}
+
+pn_vrouter_loopback { 'bgp-test-vrouter-1 172.16.1.1':
+  require => Pn_vrouter['bgp-test-vrouter-1'],
+  ensure => present,
+  switch => 'dorado-tme-1',
+}
+
+pn_vrouter { 'bgp-test-vrouter-2':
+  ensure     => present,
+  switch     => 'dorado-tme-2',
+  vnet       => 'puppet-ansible-chef-fab-global',
+  service    => 'enable',
+  hw_vrrp_id => 18,
+  bgp_as     => 65000,
+  router_id  => '172.168.10.10',
+}
+
+pn_vrouter_loopback { 'bgp-test-vrouter-2 172.16.1.2':
+  require => Pn_vrouter['bgp-test-vrouter-2'],
+  ensure => present,
+  switch => 'dorado-tme-2',
+}
+
+# create a BGP on switch 1
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.6':
+  ensure => present,
+  bgp_as => 65000,
+}
+
+# do nothing already created
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.6':
+  ensure => present,
+  bgp_as => 65000,
+}
+
+# create a BGP on switch 2
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.10':
+  ensure => present,
+  bgp_as => 65000,
+}
+
+# do nothing already created
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.10':
+  ensure => present,
+  bgp_as => 65000,
+}
+
+# remove bgp on switch1
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.6':
+  ensure => absent,
+  bgp_as => 65000,
+}
+
+# do nothing already removed
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.6':
+  ensure => absent,
+  bgp_as => 65000,
+}
+
+# remove BGP from switch 2
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.10':
+  ensure => absent,
+  bgp_as => 65000,
+}
+
+# do nothing already removed
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.10':
+  ensure => absent,
+  bgp_as => 65000,
+}
+
+# should fail, bad name
+pn_vrouter_bgp { 'bgp test vrouter 1 172.168.10.10':
+  ensure => present,
+  bgp_as => 65000,
+}
+
+# should fail, bad ip
+pn_vrouter_bgp { 'bgp-test-vrouter-1 256.1b8.c0.x0':
+  ensure => present,
+  bgp_as => 65000,
+}
+
+# should fail, bad BGP AS
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.10':
+  ensure => present,
+  bgp_as => 0,
+}
+
+# should fail, bad BGP AS
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.10':
+  ensure => present,
+  bgp_as => 4294967296,
+}
+
+# create a BGP range on switch 1
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.6-10':
+  ensure => present,
+  bgp_as => 65000,
+  increment => 4,
+}
+
+# do nothing, already there
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.6-10':
+  ensure => present,
+  bgp_as => 65000,
+  increment => 4,
+}
+
+# delete a BGP range on switch 1
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.6-10':
+  ensure => absent,
+  bgp_as => 65000,
+  increment => 4,
+}
+
+# do nothing, already gone
+pn_vrouter_bgp { 'bgp-test-vrouter-1 172.168.10.6-10':
+  ensure => absent,
+  bgp_as => 65000,
+  increment => 4,
+}
+
+# TEAR-DOWN
+
+pn_vrouter { 'bgp-test-vrouter-1':
+  ensure     => absent,
+  switch     => 'dorado-tme-1',
+  vnet       => 'puppet-ansible-chef-fab-global',
+  service    => 'enable',
+  hw_vrrp_id => 18,
+  bgp_as     => 65000,
+}
+
+pn_vrouter_loopback { 'bgp-test-vrouter-1 172.16.1.1':
+  before => Pn_vrouter['bgp-test-vrouter-1'],
+  ensure => absent,
+  switch => 'dorado-tme-1',
+}
+
+pn_vrouter { 'bgp-test-vrouter-2':
+  ensure     => absent,
+  switch     => 'dorado-tme-2',
+  vnet       => 'puppet-ansible-chef-fab-global',
+  service    => 'enable',
+  hw_vrrp_id => 18,
+  bgp_as     => 65000,
+}
+
+pn_vrouter_loopback { 'bgp-test-vrouter-2 172.16.1.2':
+  before => Pn_vrouter['bgp-test-vrouter-2'],
+  ensure => absent,
+  switch => 'dorado-tme-2',
+}
+
+#END

--- a/tests/runs/pn_vrouter_runs.pp
+++ b/tests/runs/pn_vrouter_runs.pp
@@ -188,4 +188,47 @@ pn_vrouter { 'test-vrouter-1':
   hw_vrrp_id => 'a',
 }
 
+# should warn that both BGP params aren't specified
+pn_vrouter { 'test-vrouter':
+  ensure     => present,
+  switch     => 'dorado-tme-1',
+  vnet       => 'puppet-ansible-chef-fab-global',
+  service    => 'enable',
+  hw_vrrp_id => 18,
+  router_id  => '198.175.5.10',
+}
+
+# should pass
+pn_vrouter { 'test-vrouter':
+  ensure     => present,
+  switch     => 'dorado-tme-1',
+  vnet       => 'puppet-ansible-chef-fab-global',
+  service    => 'enable',
+  hw_vrrp_id => 18,
+  bgp_as     => 65000,
+  router_id  => '198.175.5.10',
+}
+
+# should pass and change router id
+pn_vrouter { 'test-vrouter':
+  ensure     => present,
+  switch     => 'dorado-tme-1',
+  vnet       => 'puppet-ansible-chef-fab-global',
+  service    => 'enable',
+  hw_vrrp_id => 18,
+  bgp_as     => 65000,
+  router_id  => '198.175.5.6',
+}
+
+# remove
+pn_vrouter { 'test-vrouter':
+  ensure     => absent,
+  switch     => 'dorado-tme-1',
+  vnet       => 'puppet-ansible-chef-fab-global',
+  service    => 'enable',
+  hw_vrrp_id => 18,
+  bgp_as     => 65000,
+  router_id  => '198.175.5.6',
+}
+
 # END


### PR DESCRIPTION
Updated the way BGP is handled and changed vRouters to match.
#### lib/puppet/provider/pn_vrouter/netvisor.rb:
- added router-id getters and setters
- added checks to verify whether or not the router can handle BGP
#### lib/puppet/type/pn_vrouter.rb:
- added new property router_id to create an address for the vRouter
- added missing desc
#### tests/runs/pn_vrouter_runs.pp:
- testing new router_id property
#### tests/runs/pn_vrouter_bgp_runs.pp:
- created bgp test runs
#### lib/puppet/provider/pn_vrouter_bgp/netvisor.rb:
- added decon_bgp_rng method to generate an ip range from the user specified syntax
  — updated get_bgp_info to take ip as a parameter
- updated exists?, create, destroy, and all getters and setters to accept ip ranges
#### lib/puppet/type/pn_vrouter_bgp.rb:
- the namevar now follows ip ranges for the final number
- updated ip regular expression to validate new syntax
- added descs
- updated validations
#### README.md:
- update vrouter_bgp and vrouter sections
