### PR TITLE
Closes #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,8 +452,6 @@ Manage vRouter IP interfaces and vRouter VRRP interfaces. If you are creating a 
 
 **`ensure`** tells Puppet how to manage the vRouter interface. Ensuring `present` will mean that the vRouter interface will be created and present on the switch after a completed catalog run. Setting this to `absent` will ensure that the vRouter interface is not present on the system after the catalog run.
 
-**`vrouter`** is the name of the vRouter that will host and manage the interface.
-
 **_`vrrp_ip`_** is the ip of the VRRP interface. This also obeys IP pattern matching, and the only criteria is that this ip cannot be the same as the IP of the IP interface. Default is `none`.
 
 **_`vrrp_priority`_** The VRRP interface priority, this can be a number between `0` and `255`. Default is `none`.
@@ -491,7 +489,6 @@ pn_vlan { '101-102':
 pn_vrouter_if { '101-102 x.x.x.2/24':
     require       => Pn_vlan['101'],
     ensure        => present,
-    vrouter       => 'demo-vrouter',
     vrrp_ip       => 'x.x.x.1',
     vrrp_priority => '110',
 }

--- a/examples/demo_manifests/char_squirt_demo_set_up.pp
+++ b/examples/demo_manifests/char_squirt_demo_set_up.pp
@@ -75,14 +75,12 @@ pn_vlan { '101-110, 198-202':
 pn_vrouter_if { '101-105 x.x.x.2/24':
   require => Pn_vlan['101-110, 198-202'],
   ensure  => present,
-  vrouter => 'a-vrouter',
   switch  => $a,
 }
 
 pn_vrouter_if { '106-110 x.x.x.2/24':
   require       => Pn_vlan['101-110, 198-202'],
   ensure        => present,
-  vrouter       => 'a-vrouter',
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => '110',
   switch        => $a,
@@ -91,14 +89,12 @@ pn_vrouter_if { '106-110 x.x.x.2/24':
 pn_vrouter_if { '101-105 x.x.x.4/24':
   require => Pn_vlan['101-110, 198-202'],
   ensure  => present,
-  vrouter => 'b-vrouter',
   switch  => $b,
 }
 
 pn_vrouter_if { '106-110 x.x.x.4/24':
   require       => Pn_vlan['101-110, 198-202'],
   ensure        => present,
-  vrouter       => 'b-vrouter',
   vrrp_ip       => 'x.x.x.3/24',
   vrrp_priority => '110',
   switch        => $b,

--- a/examples/demo_manifests/char_squirt_demo_tear_down.pp
+++ b/examples/demo_manifests/char_squirt_demo_tear_down.pp
@@ -75,14 +75,12 @@ pn_vlan { '101-110, 198-202':
 pn_vrouter_if { '101-105 x.x.x.2/24':
   before  => Pn_vlan['101-110, 198-202'],
   ensure  => absent,
-  vrouter => 'a-vrouter',
   switch  => $a,
 }
 
 pn_vrouter_if { '106-110 x.x.x.2/24':
   before        => Pn_vlan['101-110, 198-202'],
   ensure        => absent,
-  vrouter       => 'a-vrouter',
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => '110',
   switch        => $a,
@@ -91,14 +89,12 @@ pn_vrouter_if { '106-110 x.x.x.2/24':
 pn_vrouter_if { '101-105 x.x.x.4/24':
   before  => Pn_vlan['101-110, 198-202'],
   ensure  => absent,
-  vrouter => 'b-vrouter',
   switch  => $b,
 }
 
 pn_vrouter_if { '106-110 x.x.x.4/24':
   before        => Pn_vlan['101-110, 198-202'],
   ensure        => absent,
-  vrouter       => 'b-vrouter',
   vrrp_ip       => 'x.x.x.3/24',
   vrrp_priority => '110',
   switch        => $b,

--- a/lib/puppet/provider/pn_vlag/netvisor.rb
+++ b/lib/puppet/provider/pn_vlag/netvisor.rb
@@ -75,17 +75,33 @@ Puppet::Type.type(:pn_vlag).provide(:netvisor) do
   end
 
   def create
-    cli('switch', @switch1, 'vlag-create',
-        'name', resource[:name],
-        'port', resource[:port],
-        'peer-port', resource[:peer_port],
-        'mode', "active-#{resource[:mode]}",
-        'peer-switch', @switch2,
-        "failover-#{resource[:failover]}-L2",
-        'lacp-mode', resource[:lacp_mode],
-        'lacp-timeout', resource[:lacp_timeout],
-        'lacp-fallback', resource[:lacp_fallback],
-        'lacp-fallback-timeout', resource[:lacp_fallback_timeout])
+    # switch port and peer-port positions if try 1 errors, need to replace with
+    # something other than a try-catch
+    begin
+      cli('switch', @switch1, 'vlag-create',
+          'name', resource[:name],
+          'port', resource[:port],
+          'peer-port', resource[:peer_port],
+          'mode', "active-#{resource[:mode]}",
+          'peer-switch', @switch2,
+          "failover-#{resource[:failover]}-L2",
+          'lacp-mode', resource[:lacp_mode],
+          'lacp-timeout', resource[:lacp_timeout],
+          'lacp-fallback', resource[:lacp_fallback],
+          'lacp-fallback-timeout', resource[:lacp_fallback_timeout])
+    rescue
+      cli('switch', @switch1, 'vlag-create',
+          'name', resource[:name],
+          'port', resource[:peer_port],
+          'peer-port', resource[:port],
+          'mode', "active-#{resource[:mode]}",
+          'peer-switch', @switch2,
+          "failover-#{resource[:failover]}-L2",
+          'lacp-mode', resource[:lacp_mode],
+          'lacp-timeout', resource[:lacp_timeout],
+          'lacp-fallback', resource[:lacp_fallback],
+          'lacp-fallback-timeout', resource[:lacp_fallback_timeout])
+    end
   end
 
   mk_resource_methods

--- a/lib/puppet/type/pn_vlan.rb
+++ b/lib/puppet/type/pn_vlan.rb
@@ -14,7 +14,7 @@
 
 require File.expand_path(
     File.join(File.dirname(__FILE__),
-              '..', '..', '..', 'puppet_x', 'pn', 'mixin_helper.rb'))
+              '..', '..', 'puppet_x', 'pn', 'mixin_helper.rb'))
 
 include PuppetX::Pluribus::MixHelper
 

--- a/lib/puppet/type/pn_vrouter_if.rb
+++ b/lib/puppet/type/pn_vrouter_if.rb
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require File.expand_path(
+    File.join(File.dirname(__FILE__),
+              '..', '..', 'puppet_x', 'pn', 'mixin_helper.rb'))
+
+include PuppetX::Pluribus::MixHelper
+
+
 Puppet::Type.newtype(:pn_vrouter_if) do
 
   @doc = "Manage vRouter IP interfaces and vRouter VRRP interfaces. If you are
@@ -96,8 +103,7 @@ pn_vrouter_if { '101-102 x.x.x.2/24':
       unless v.first =~ /^((\d{1,4}-\d{1,4})|(\d{1,4})[,\s$]*){1,}$|^(\d{1,4})$/
         raise ArgumentError, 'vLAN ID must be a number or range of numbers'
       end
-      @H = PuppetX::Pluribus::PnHelper.new
-      ids = @H.deconstruct_range(v.first)
+      ids = deconstruct_range(v.first)
       ids.each do |i|
         unless (2..4092) === i.to_i #i.to_i.between?(2, 4092)
           raise ArgumentError, 'vLAN ID must be between 2 and 4092'
@@ -124,16 +130,6 @@ pn_vrouter_if { '101-102 x.x.x.2/24':
     end
   end
 
-  newproperty(:vrouter) do
-    desc "The name of the vRouter that will host and manage the IP interface."
-    validate do |value|
-      if value =~ /[^\w.:-]/
-        raise ArgumentError, 'vRouter name can only contain letters, ' +
-            'numbers, _, ., :, and -'
-      end
-    end
-  end
-
   newproperty(:vrrp_ip) do
     desc "The ip of the VRRP interface."
     defaultto('none')
@@ -151,7 +147,7 @@ pn_vrouter_if { '101-102 x.x.x.2/24':
     desc "The priority for the VRRP interface."
     defaultto('none')
     validate do |value|
-      unless value =~ /^(2[0-5][0-5]|1[0-9][0-9]|[0-9][0-9]|[0-9])$/ or
+      unless value.to_s =~ /^(2[0-5][0-5]|1[0-9][0-9]|[0-9][0-9]|[0-9])$/ or
           value == 'none'
         raise ArgumentError, 'vrrp_priority must be a number between 0 and 255'
       end

--- a/tests/runs/pn_vrouter_interface_runs.pp
+++ b/tests/runs/pn_vrouter_interface_runs.pp
@@ -15,7 +15,7 @@
 # SET-UP
 pn_vrouter { 'test-vrouter':
   ensure     => present,
-  switch     => 'dorado-tme-1',
+  switch     => 'charmander.pluribusnetworks.com',
   vnet       => 'puppet-ansible-chef-fab-global',
   service    => 'enable',
   hw_vrrp_id => 18,
@@ -29,13 +29,11 @@ pn_vlan { '101':
 # create an interface
 pn_vrouter_if { '101 x.x.x.3/24':
   ensure  => present,
-  vrouter => 'test-vrouter',
 }
 
 # should do nothing, already exists
 pn_vrouter_if { '101 x.x.x.3/24':
   ensure  => present,
-  vrouter => 'test-vrouter',
 }
 
 # should create a range
@@ -46,13 +44,11 @@ pn_vlan { '102-105':
 pn_vrouter_if { '102-105 x.x.x.3/24':
   require => Pn_vlan['102-105'],
   ensure  => present,
-  vrouter => 'test-vrouter',
 }
 
 # should do nothing
 pn_vrouter_if { '102-105 x.x.x.3/24':
   ensure  => present,
-  vrouter => 'test-vrouter',
 }
 
 # should delete range
@@ -63,19 +59,16 @@ pn_vlan { '102-105':
 pn_vrouter_if { '102-105 x.x.x.3/24':
   before  => Pn_vlan['102-105'],
   ensure  => absent,
-  vrouter => 'test-vrouter',
 }
 
 # should do nothing, already deleted
 pn_vrouter_if { '102-105 x.x.x.3/24':
   ensure  => absent,
-  vrouter => 'test-vrouter',
 }
 
 # create a vrrp interface
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => present,
-  vrouter       => test-vrouter,
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => 110
 }
@@ -83,7 +76,6 @@ pn_vrouter_if { '101 x.x.x.2/24':
 # should do nothing, already created
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => present,
-  vrouter       => test-vrouter,
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => 110
 }
@@ -91,7 +83,6 @@ pn_vrouter_if { '101 x.x.x.2/24':
 # delete a vrrp interface
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => absent,
-  vrouter       => test-vrouter,
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => 110
 }
@@ -99,7 +90,6 @@ pn_vrouter_if { '101 x.x.x.2/24':
 # should do nothing already deleted
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => absent,
-  vrouter       => test-vrouter,
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => 110
 }
@@ -107,13 +97,11 @@ pn_vrouter_if { '101 x.x.x.2/24':
 # should fail, incorrect namevar, no netmask
 pn_vrouter_if { '101 x.x.x.2':
   ensure  => present,
-  vrouter => test-vrouter,
 }
 
 # should fail, vrrp_ip matches interface ip
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => present,
-  vrouter       => test-vrouter,
   vrrp_ip       => 'x.x.x.2/24',
   vrrp_priority => 110
 }
@@ -121,7 +109,6 @@ pn_vrouter_if { '101 x.x.x.2/24':
 # should fail, vrouter doesn't exist
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => present,
-  vrouter       => test-vrouter-fake,
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => 110
 }
@@ -129,7 +116,6 @@ pn_vrouter_if { '101 x.x.x.2/24':
 # create a vrrp interface
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => present,
-  vrouter       => test-vrouter,
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => 110
 }
@@ -137,7 +123,6 @@ pn_vrouter_if { '101 x.x.x.2/24':
 # change vrrp_id
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => present,
-  vrouter       => test-vrouter,
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => 110
 }
@@ -145,13 +130,11 @@ pn_vrouter_if { '101 x.x.x.2/24':
 # create an interface
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure  => present,
-  vrouter => 'test-vrouter',
 }
 
 # make it vrrp
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => present,
-  vrouter       => test-vrouter,
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => 110
 }
@@ -159,7 +142,6 @@ pn_vrouter_if { '101 x.x.x.2/24':
 # change priority
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => present,
-  vrouter       => test-vrouter,
   vrrp_ip       => 'x.x.x.1/24',
   vrrp_priority => 118
 }
@@ -167,16 +149,29 @@ pn_vrouter_if { '101 x.x.x.2/24':
 # change vrrp ip
 pn_vrouter_if { '101 x.x.x.2/24':
   ensure        => present,
-  vrouter       => test-vrouter,
   vrrp_ip       => 'x.x.x.4/24',
   vrrp_priority => 118
+}
+
+# should pass
+pn_vrouter { 'test-vrouter':
+  ensure     => absent,
+  switch     => 'charmander.pluribusnetworks.com',
+  vnet       => 'puppet-ansible-chef-fab-global',
+  service    => 'enable',
+  hw_vrrp_id => 18,
+}
+
+pn_vrouter_if { '101 x.x.x.2/24':
+  ensure  => present,
+  require => Pn_vrouter['test-vrouter'],
 }
 
 
 # TEAR-DOWN
 pn_vrouter { 'test-vrouter':
   ensure     => absent,
-  switch     => 'dorado-tme-1',
+  switch     => 'charmander.pluribusnetworks.com',
   vnet       => 'puppet-ansible-chef-fab-global',
   service    => 'enable',
   hw_vrrp_id => 18,


### PR DESCRIPTION
Removal of the vrouter property from vrouter_if. During testing this fix I discovered a few bugs related to vrouters and vrouter_if that are also fixed by this commit
#### examples/demo_manifests/char_squirt_demo_set_up.pp:
- modified to accept new vrouter_if properties
#### examples/demo_manifests/char_squirt_demo_tear_down.pp:
- modified to accept new vrouter_if properties
#### lib/puppet/provider/pn_vlag/netvisor.rb:
- found and fixed bug where vlag creation would error out because the port and peer-port weren’t synced to the switches in the specified cluster
#### lib/puppet/provider/pn_vrouter_if/netvisor.rb:
- switch to mixin helper
- changed exists to find vrouter on the current switch
- added in logic to create a vrouter if one doesn’t exist
- also creates a missing vlan
- uses global @vrouter instead of resource[:vrouter]
#### lib/puppet/type/pn_vlan.rb:
- require path was broken, fixed
#### lib/puppet/type/pn_vrouter_if.rb:
- added mixin helper
- fixed vrrp_priority validation
- removed vrouter property (Duh :stuck_out_tongue_closed_eyes:)
#### lib/puppet_x/pn/mixin_helper.rb:
- added build_ip method from old helper
#### tests/runs/pn_vrouter_interface_runs.pp:
- updated to run without vrouter property
