### PR TITLE
Closes #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ pn_vlan { '101':
 ---
 ### pn_vrouter
 
-Manage vRouters.
+Manage vRouters. On systems that only allow one vRouter the latest executed vRouter deceleration will be created.
 
 #### Properties
 
@@ -444,7 +444,7 @@ pn_vrouter_bgp { 'demo-vrouter 101.101.101.2-10':
 ---
 ### pn_vrouter_if
 
-Manage vRouter IP interfaces and vRouter VRRP interfaces. If you are creating a VRRP interface you must specify both `vrrp_ip` and `vrrp_priority`, otherwise and IP interface will be created. When you create a VRRP interface, pn_vrouter_if creates an IP interface AND a VRRP interface in one resource deceleration.
+Manage vRouter IP interfaces and vRouter VRRP interfaces. If you are creating a VRRP interface you must specify both `vrrp_ip` and `vrrp_priority`, otherwise and IP interface will be created. When you create a VRRP interface, pn_vrouter_if creates an IP interface AND a VRRP interface in one resource deceleration. If you don't create a vRouter prior to creating a vRouter interface the interface will make one. If you create a vRouter after a vRouter interface with a diffrent name the vRouter interface will be removed. Be careful and use Before and Require statements.
 
 #### Properties
 

--- a/lib/puppet/provider/pn_vrouter/netvisor.rb
+++ b/lib/puppet/provider/pn_vrouter/netvisor.rb
@@ -33,8 +33,17 @@ Puppet::Type.type(:pn_vrouter).provide(:netvisor) do
   end
 
   def exists?
+
     @BGP = (resource[:bgp_as] != '' and resource[:router_id] != 'none') ?
         true : false
+
+    vrouter = cli('vrouter-show', 'location', switch_location,
+                  'format', 'name', PDQ).strip
+    if vrouter != '' and vrouter != resource[:name]
+      cli('vrouter-delete', 'name', vrouter, Q)
+      return false
+    end
+
     unless cli(*splat_switch, Q) == ''
       fail("Switch #{resource[:switch]} could not be found on the fabric.")
     end

--- a/lib/puppet/provider/pn_vrouter_if/netvisor.rb
+++ b/lib/puppet/provider/pn_vrouter_if/netvisor.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:pn_vrouter_if).provide(:netvisor) do
 
   def exists?
 
-    location = resource[:switch] == :local ? `hostname`.strip : resource[:switch]
+    location = switch_location
 
     vrouter_locations = cli('vrouter-show', 'format',
                             'location', PDQ).split("\n")

--- a/lib/puppet_x/pn/mixin_helper.rb
+++ b/lib/puppet_x/pn/mixin_helper.rb
@@ -106,6 +106,16 @@ module PuppetX
         ip_out
       end
 
+      # Returns the name of the current switch, use this if you need the actual
+      # location but there is a possibility that switch is defined as local.
+      # This is some really simple logic but I find myself using it a lot.
+      # @param defined: The switch name, defaults to resource[:switch]
+      # @return: A string containing the hostname of the system being managed
+      #
+      def switch_location(defined=resource[:switch])
+        defined == :local ? `hostname`.strip : defined
+      end
+
     end
 
   end

--- a/tests/runs/pn_vrouter_runs.pp
+++ b/tests/runs/pn_vrouter_runs.pp
@@ -220,8 +220,20 @@ pn_vrouter { 'test-vrouter':
   router_id  => '198.175.5.6',
 }
 
+# should pass and delete the old router and create the new one
+pn_vrouter { 'test-vrouter-overwrite':
+  ensure     => present,
+  switch     => 'charmander.pluribusnetworks.com',
+  vnet       => 'puppet-ansible-chef-fab-global',
+  service    => 'enable',
+  hw_vrrp_id => 18,
+  bgp_as     => 65000,
+  router_id  => '198.175.5.6',
+}
+
+
 # remove
-pn_vrouter { 'test-vrouter':
+pn_vrouter { 'test-vrouter-overwrite':
   ensure     => absent,
   switch     => 'charmander.pluribusnetworks.com',
   vnet       => 'puppet-ansible-chef-fab-global',


### PR DESCRIPTION
new vrouters will now over-write vrouters present on the specified switch
#### README.md:
- added warnings related to new behavior
#### lib/puppet/provider/pn_vrouter/netvisor.rb:
- simply added logic to check if a vrouter is already present and deletes it if it is present
#### lib/puppet/provider/pn_vrouter_if/netvisor.rb:
- updated to use new helper method
#### lib/puppet_x/pn/mixin_helper.rb:
- added switch_location method
#### tests/runs/pn_vrouter_runs.pp:
- added overwrite tests
